### PR TITLE
Show solutions for incorrect answers and remove builder/lesson modes

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,9 +27,6 @@
   <script src="data/questions.js"></script>
   <!-- Override essay questions with IB DP Economics Paper 1 prompts -->
   <script src="data/paper1_essay.js"></script>
-  <!-- Load lesson data for Lesson Mode. This script defines
-       window.LESSON_DATA used by the LessonScene. -->
-  <script src="data/lesson_data.js"></script>
   <!-- The main game script. Avoid using ES6 module loading on the file:// scheme which can
        trigger cross‑origin restrictions in some browsers. We use a classic script tag
        instead so the game runs when opened locally without an HTTP server. -->

--- a/style.css
+++ b/style.css
@@ -107,26 +107,6 @@ html, body {
   justify-content: space-between;
 }
 
-/* Layout for the Diagram Builder scene */
-#builder-wrapper {
-  display: flex;
-  width: 860px;
-  height: 560px;
-}
-.builder-toolbox,
-.builder-info {
-  width: 20%;
-  padding: 10px;
-  box-sizing: border-box;
-  background: #e7eef5;
-  overflow-y: auto;
-}
-.builder-canvas {
-  flex: 1;
-  border: 1px solid #ccc;
-  background: #ffffff;
-}
-
 /* Simple container for Adaptive Learning scene */
 .adaptive-container {
   width: 80%;


### PR DESCRIPTION
## Summary
- Remove Diagram Builder and Lesson modes from menu and game configuration.
- Automatically reveal solutions after incorrect responses across question modes; include step-by-step calculation fixes.
- Require users to click Continue after viewing solutions for more reflection time.

## Testing
- `npm test` *(fails: could not read package.json)*
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_689e38974b688330950a524085cf12e1